### PR TITLE
Instant camera setup/teardown on visibility hint

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/co/krypt/kryptonite/help/HelpFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/help/HelpFragment.java
@@ -44,16 +44,30 @@ public class HelpFragment extends Fragment {
         TabHost host = (TabHost) root.findViewById(R.id.installInstructions);
         host.setup();
 
-        //Tab 1
-        TabHost.TabSpec spec = host.newTabSpec("curl");
-        spec.setContent(R.id.tab1);
-        spec.setIndicator("curl");
-        host.addTab(spec);
+        TabHost.TabSpec specCurl = host.newTabSpec("curl");
+        specCurl.setContent(R.id.tab1);
+        specCurl.setIndicator("curl");
+        host.addTab(specCurl);
+
+        TabHost.TabSpec specBrew = host.newTabSpec("brew");
+        specBrew.setContent(R.id.tab2);
+        specBrew.setIndicator("brew");
+        host.addTab(specBrew);
+
+        TabHost.TabSpec specNPM = host.newTabSpec("npm");
+        specNPM.setContent(R.id.tab3);
+        specNPM.setIndicator("npm");
+        host.addTab(specNPM);
+
+        TabHost.TabSpec specMore = host.newTabSpec("more");
+        specMore.setContent(R.id.tab4);
+        specMore.setIndicator("more");
+        host.addTab(specMore);
 
         host.setOnTabChangedListener(new TabHost.OnTabChangeListener() {
             @Override
             public void onTabChanged(String tabId) {
-                new Analytics(getContext()).postEvent("install", tabId, null, null, false);
+                new Analytics(getContext()).postEvent("help_install", tabId, null, null, false);
             }
         });
 

--- a/app/src/main/java/co/krypt/kryptonite/knownhosts/KnownHostsRecyclerViewAdapter.java
+++ b/app/src/main/java/co/krypt/kryptonite/knownhosts/KnownHostsRecyclerViewAdapter.java
@@ -15,6 +15,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 import co.krypt.kryptonite.R;
+import co.krypt.kryptonite.analytics.Analytics;
 import co.krypt.kryptonite.silo.Silo;
 
 
@@ -69,6 +70,7 @@ public class KnownHostsRecyclerViewAdapter extends RecyclerView.Adapter<KnownHos
                             public void onClick(DialogInterface dialog, int id) {
                                 try {
                                     Silo.shared(activity.getApplicationContext()).deleteKnownHost(holder.knownHost.hostName);
+                                    new Analytics(activity.getApplicationContext()).postEvent("known_host", "delete", null, null, false);
                                 } catch (SQLException e) {
                                     e.printStackTrace();
                                 }

--- a/app/src/main/java/co/krypt/kryptonite/onboarding/FirstPairFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/onboarding/FirstPairFragment.java
@@ -62,10 +62,22 @@ public class FirstPairFragment extends Fragment {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        pairFragment.setUserVisibleHint(true);
+        pairFragment.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        pairFragment.onPause();
+        super.onPause();
+    }
+
+    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         getChildFragmentManager().beginTransaction().add(R.id.pairLayout, pairFragment).commit();
-        pairFragment.setUserVisibleHint(true);
 
         View root = inflater.inflate(R.layout.fragment_first_pair, container, false);
         Button nextButton = (Button) root.findViewById(R.id.nextButton);

--- a/app/src/main/java/co/krypt/kryptonite/onboarding/FirstPairFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/onboarding/FirstPairFragment.java
@@ -79,16 +79,30 @@ public class FirstPairFragment extends Fragment {
         TabHost host = (TabHost) root.findViewById(R.id.installInstructions);
         host.setup();
 
-        //Tab 1
         TabHost.TabSpec spec = host.newTabSpec("curl");
         spec.setContent(R.id.tab1);
         spec.setIndicator("curl");
         host.addTab(spec);
 
+        TabHost.TabSpec specBrew = host.newTabSpec("brew");
+        specBrew.setContent(R.id.tab2);
+        specBrew.setIndicator("brew");
+        host.addTab(specBrew);
+
+        TabHost.TabSpec specNPM = host.newTabSpec("npm");
+        specNPM.setContent(R.id.tab3);
+        specNPM.setIndicator("npm");
+        host.addTab(specNPM);
+
+        TabHost.TabSpec specMore = host.newTabSpec("more");
+        specMore.setContent(R.id.tab4);
+        specMore.setIndicator("more");
+        host.addTab(specMore);
+
         host.setOnTabChangedListener(new TabHost.OnTabChangeListener() {
             @Override
             public void onTabChanged(String tabId) {
-                new Analytics(getContext()).postEvent("install", tabId, null, null, false);
+                new Analytics(getContext()).postEvent("onboard_install", tabId, null, null, false);
             }
         });
 

--- a/app/src/main/java/co/krypt/kryptonite/pairing/CameraPreview.java
+++ b/app/src/main/java/co/krypt/kryptonite/pairing/CameraPreview.java
@@ -2,13 +2,13 @@ package co.krypt.kryptonite.pairing;
 
 
 import android.content.Context;
+import android.graphics.PixelFormat;
 import android.hardware.Camera;
 import android.util.Log;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
 import java.io.IOException;
-import java.util.List;
 
 /** A basic Camera preview class https://developer.android.com/guide/topics/media/camera.html#preview-layout */
 
@@ -26,36 +26,27 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
         // underlying surface is created and destroyed.
         mHolder = getHolder();
         mHolder.addCallback(this);
-        // deprecated setting, but required on Android versions prior to 3.0
-        mHolder.setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);
     }
 
-    public void surfaceCreated(SurfaceHolder holder) {
-        Log.d(TAG, "surfaceCreated");
-    }
+    public void surfaceCreated(SurfaceHolder holder) {}
+    public void surfaceDestroyed(SurfaceHolder holder) {}
+    public void surfaceChanged(SurfaceHolder holder, int format, int w, int h) {}
 
-    public void surfaceDestroyed(SurfaceHolder holder) {
-    }
-
-    public void setCamera(Camera camera) {
+    public void setup(Camera camera) {
         // The Surface has been created, now tell the camera where to draw the preview.
         try {
             camera.setPreviewDisplay(mHolder);
-            camera.startPreview();
-            List<String> focusModes = camera.getParameters().getSupportedFocusModes();
-            if (focusModes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
-                Camera.Parameters params = camera.getParameters();
-                params.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
-                camera.setParameters(params);
-            }
             previewSize = camera.getParameters().getPreviewSize();
         } catch (IOException e) {
             Log.d(TAG, "Error setting camera preview: " + e.getMessage());
         }
     }
 
-    public void surfaceChanged(SurfaceHolder holder, int format, int w, int h) {
-        return;
+    public void clear() {
+        // This trick rebuilds the surface, making it black again. Starting with a black surface
+        // while the camera loads looks nicer than having an odd frozen image from previous run.
+        mHolder.setFormat(PixelFormat.TRANSPARENT);
+        mHolder.setFormat(PixelFormat.OPAQUE);
     }
 
     public Camera.Size getPreviewSize() {

--- a/app/src/main/java/co/krypt/kryptonite/pairing/PairFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/pairing/PairFragment.java
@@ -22,7 +22,11 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import java.util.concurrent.ThreadPoolExecutor;
 
 import co.krypt.kryptonite.MainActivity;
 import co.krypt.kryptonite.R;
@@ -39,16 +43,17 @@ import co.krypt.kryptonite.silo.Silo;
  * Use the {@link PairFragment#newInstance} factory method to
  * create an instance of this fragment.
  */
-public class PairFragment extends Fragment implements Camera.PreviewCallback, PairDialogFragment.PairListener {
+public class PairFragment extends Fragment implements PairDialogFragment.PairListener {
     private static final String TAG = "PairFragment";
     public static final String PAIRING_SUCCESS_ACTION = "co.krypt.android.action.PAIRING_SUCCESS";
 
+    // This threadpool should only contain one thread. It is used to perform background tasks
+    // synchronized amongst each other.
+    private ThreadPoolExecutor threadPool;
+
     private Camera mCamera;
-    private int previewWidth;
-    private int previewHeight;
     private CameraPreview mPreview;
     private CroppedCameraPreview preview;
-    private boolean visible;
 
     private View pairingStatusView;
     private TextView pairingStatusText;
@@ -81,6 +86,8 @@ public class PairFragment extends Fragment implements Camera.PreviewCallback, Pa
     }
 
     public PairFragment() {
+        // 1 core thread, 1 max thread, 60 second timeout.
+        threadPool = new ThreadPoolExecutor(1, 1, 60, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>());
     }
 
     public synchronized void onPairingScanned(PairingQR pairingQR) {
@@ -96,24 +103,12 @@ public class PairFragment extends Fragment implements Camera.PreviewCallback, Pa
     @Override
     public void setUserVisibleHint(boolean visible) {
         super.setUserVisibleHint(visible);
-        if (visible && isResumed())
-        {
-            //Only manually call onResume if fragment is already visible
-            //Otherwise allow natural fragment lifecycle to call onResume
-            onResume();
+        if (visible && isResumed()) {
+            startCamera(getContext());
+            refreshCameraPermissionInfoVisibility();
+        } else {
+            stopCamera();
         }
-        synchronized (this) {
-            this.visible = visible;
-            Log.d(TAG, "visible: " + visible);
-            if (visible) {
-                if (resumed) {
-                    startCamera(getContext());
-                }
-            } else {
-                delayedStopCamera();
-            }
-        }
-        refreshCameraPermissionInfoVisibility();
     }
 
     /**
@@ -196,11 +191,6 @@ public class PairFragment extends Fragment implements Camera.PreviewCallback, Pa
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
-    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
@@ -249,22 +239,6 @@ public class PairFragment extends Fragment implements Camera.PreviewCallback, Pa
         return rootView;
     }
 
-    /** A safe way to get an instance of the Camera object. */
-    public static Camera getCameraInstance(){
-        Camera c = null;
-        try {
-            c = Camera.open(); // attempt to get a Camera instance
-            if (c != null) {
-                c.setDisplayOrientation(90);
-            }
-        }
-        catch (Exception e){
-            // Camera is not available (in use or does not exist)
-            e.printStackTrace();
-        }
-        return c; // returns null if camera is unavailable
-    }
-
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
@@ -289,118 +263,71 @@ public class PairFragment extends Fragment implements Camera.PreviewCallback, Pa
         getContext().unregisterReceiver(permissionReceiver);
     }
 
-    synchronized private void startCamera(final Context context) {
-        stopCameraEpoch.incrementAndGet();
+    private void startCamera(final Context context) {
         final PairFragment self = this;
-        if (mCamera != null) {
-            return;
-        }
-        new Thread(new Runnable() {
+
+        // Execute on threadPool to guarantee start/stop request ordering.
+        threadPool.execute(new Runnable() {
+            @Override
             public void run() {
-                final Camera camera = getCameraInstance();
-                if (camera == null) {
+                if (mCamera != null) {
                     return;
                 }
 
-                new Handler(Looper.getMainLooper()).post(new Runnable() {
-                    @Override
-                    public void run() {
-                        synchronized (self) {
-                            mCamera = camera;
-                            previewWidth = camera.getParameters().getPreviewSize().width;
-                            previewHeight = camera.getParameters().getPreviewSize().height;
-                            mPreview.setCamera(mCamera);
-                            new Thread(new Runnable() {
-                                @Override
-                                public void run() {
-                                    synchronized (self) {
-                                        camera.setPreviewCallback(self);
-                                        pairScanner = new PairScanner(context, self, previewHeight, previewWidth);
-                                    }
-                                }
-                            }).start();
-
-                            preview.requestLayout();
-                        }
-                    }
-                });
-
-            }
-        }).start();
-    }
-
-    //  Stop camera after 10 seconds unless started again (epoch has changed)
-    private AtomicLong stopCameraEpoch = new AtomicLong(0);
-    synchronized private void delayedStopCamera() {
-        final long epoch = stopCameraEpoch.get();
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
                 try {
-                    Thread.sleep(10*1000);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-                synchronized (PairFragment.this) {
-                    if (stopCameraEpoch.get() == epoch) {
-                        stopCamera();
+                    mCamera = Camera.open();
+                    if (mCamera == null) {
+                        return;
                     }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return;
                 }
+
+                // Configure camera
+                mCamera.setDisplayOrientation(90);
+                List<String> focusModes = mCamera.getParameters().getSupportedFocusModes();
+                if (focusModes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
+                    Camera.Parameters params = mCamera.getParameters();
+                    params.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
+                    mCamera.setParameters(params);
+                }
+
+                // Setup PairScanner
+                int previewWidth = mCamera.getParameters().getPreviewSize().width;
+                int previewHeight = mCamera.getParameters().getPreviewSize().height;
+
+                pairScanner = new PairScanner(context, self, previewHeight, previewWidth);
+                mCamera.setPreviewCallback(pairScanner);
+
+                // Start preview
+                mPreview.setup(mCamera);
+                mCamera.startPreview();
             }
-        }).start();
+        });
     }
 
-    synchronized private void stopCamera() {
-        if (mCamera != null) {
-            mCamera.stopPreview();
-            mCamera.setPreviewCallback(null);
-            mCamera.unlock();
-            mCamera.release();
-            mCamera = null;
-        }
-        if (pairScanner != null) {
-            pairScanner.stop();
-            pairScanner = null;
-        }
-    }
-
-    private boolean resumed;
-    @Override
-    public void onResume() {
-        super.onResume();
-        synchronized (this) {
-            this.resumed = true;
-            if (visible) {
-                startCamera(getContext());
-            }
-        }
-        Log.i(TAG, "resume");
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        synchronized (this) {
-            this.resumed = false;
-        }
-        Log.i(TAG, "pause");
-        stopCamera();
-    }
-
-    @Override
-    public void onPreviewFrame(byte[] data, Camera camera) {
-        boolean visible;
-        synchronized (this) {
-            visible = this.visible;
-            if (!visible) {
-                return;
-            }
-            if (pairScanner != null) {
-                pairScanner.pushFrame(data);
-            } else {
-                Log.e(TAG, "pairScanner null");
-            }
-        }
+   private void stopCamera() {
+       // Execute on threadPool to guarantee start/stop request ordering.
+       threadPool.execute(new Runnable() {
+           @Override
+           public void run() {
+               if (mCamera != null) {
+                   mCamera.stopPreview();
+                   mCamera.setPreviewCallback(null);
+                   mCamera.unlock();
+                   mCamera.release();
+                   mCamera = null;
+               }
+               if (pairScanner != null) {
+                   pairScanner.stop();
+                   pairScanner = null;
+               }
+               if (mPreview != null) {
+                   mPreview.clear();
+               }
+           }
+       });
     }
 
     private synchronized void onPairingSuccess(final Pairing pairing) {

--- a/app/src/main/java/co/krypt/kryptonite/pairing/PairFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/pairing/PairFragment.java
@@ -297,7 +297,6 @@ public class PairFragment extends Fragment implements PairDialogFragment.PairLis
             Log.v(TAG, "stopping camera");
             mCamera.stopPreview();
             mCamera.setPreviewCallback(null);
-            mCamera.unlock();
             mCamera.release();
             mCamera = null;
         }

--- a/app/src/main/java/co/krypt/kryptonite/settings/Settings.java
+++ b/app/src/main/java/co/krypt/kryptonite/settings/Settings.java
@@ -11,6 +11,7 @@ import android.content.SharedPreferences;
 public class Settings {
     public static final String ENABLE_APPROVED_NOTIFICATIONS_KEY = "ENABLE_APPROVED_NOTIFICATIONS";
     public static final String SILENCE_NOTIFICATIONS_KEY = "SILENCE_NOTIFICATIONS";
+
     private static Object lock = new Object();
     private SharedPreferences preferences;
 
@@ -41,4 +42,5 @@ public class Settings {
             preferences.edit().putBoolean(SILENCE_NOTIFICATIONS_KEY, b).commit();
         }
     }
+
 }

--- a/app/src/main/java/co/krypt/kryptonite/settings/SettingsFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/settings/SettingsFragment.java
@@ -177,7 +177,7 @@ public class SettingsFragment extends Fragment {
                 KnownHostsFragment knownHostsFragment = new KnownHostsFragment();
                 transaction.setCustomAnimations(R.anim.enter_from_bottom, R.anim.delayed)
                         .replace(R.id.fragmentOverlay, knownHostsFragment).commit();
-                new Analytics(getActivity().getApplicationContext()).postPageView("KnownHosts");
+                new Analytics(getActivity().getApplicationContext()).postPageView("KnownHostsEdit");
             }
         });
 

--- a/app/src/main/java/co/krypt/kryptonite/silo/Silo.java
+++ b/app/src/main/java/co/krypt/kryptonite/silo/Silo.java
@@ -378,7 +378,7 @@ public class Silo {
                     e.printStackTrace();
                 } catch (MismatchedHostKeyException e) {
                     response.signResponse.error = "Host public key mismatched";
-                    Notifications.notifyReject(context, pairing, request, "Host public key mismatched.");
+                    Notifications.notifyReject(context, pairing, request, "host public key mismatched.");
                     e.printStackTrace();
                 }
             } else {

--- a/app/src/main/res/layout/fragment_device_detail.xml
+++ b/app/src/main/res/layout/fragment_device_detail.xml
@@ -36,12 +36,12 @@
             android:paddingRight="20dp">
 
             <ImageView
-                android:layout_width="75dp"
-                app:srcCompat="@drawable/imac"
                 android:id="@+id/imacImage"
-                android:layout_height="75dp"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintLeft_toLeftOf="parent" />
+                app:srcCompat="@drawable/imac" />
 
             <TextView
                 android:text="TextView"
@@ -53,8 +53,8 @@
                 tools:layout_constraintTop_creator="1"
                 tools:layout_constraintLeft_creator="1"
                 app:layout_constraintLeft_toRightOf="@+id/imacImage"
-                app:layout_constraintTop_toTopOf="@id/imacImage"
-                app:layout_constraintBottom_toBottomOf="@id/imacImage"
+                app:layout_constraintTop_toTopOf="@+id/imacImage"
+                app:layout_constraintBottom_toBottomOf="@+id/imacImage"
                 android:ellipsize="end"
                 android:maxLines="1"
                 android:textColor="@color/appBlack"
@@ -113,7 +113,53 @@
                     app:layout_constraintLeft_toRightOf="@+id/temporaryApprovalButton"
                     app:layout_constraintRight_toRightOf="parent"
                     android:id="@+id/automaticApprovalButton"
-                    tools:layout_editor_absoluteY="50dp" />
+                    tools:layout_editor_absoluteY="50dp"
+                    android:layout_marginTop="4dp" />
+            </android.support.constraint.ConstraintLayout>
+
+            <android.support.constraint.ConstraintLayout
+                android:id="@+id/requireUnknownHostApprovalContainer"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:background="@color/appWhite"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/approvalSettingsLayout"
+                android:layout_marginTop="6dp">
+
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="1dp"
+                    android:background="@color/appGray"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <Switch
+                    android:id="@+id/requireUnknownHostApprovalSwitch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:text=""
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    android:layout_marginTop="6dp" />
+
+                <TextView
+                    android:id="@+id/requireUnknownHostApprovalHeader"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginTop="6dp"
+                    android:text="Always ask for unknown hosts"
+                    android:textStyle="normal"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toLeftOf="@+id/requireUnknownHostApprovalSwitch"
+                    app:layout_constraintTop_toTopOf="parent" />
+
             </android.support.constraint.ConstraintLayout>
 
             <Button
@@ -121,7 +167,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:id="@+id/unpairButton"
-                app:layout_constraintTop_toBottomOf="@+id/approvalSettingsLayout"
+                app:layout_constraintTop_toBottomOf="@+id/requireUnknownHostApprovalContainer"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
                 android:textColor="@android:color/holo_red_light"

--- a/app/src/main/res/layout/fragment_first_pair.xml
+++ b/app/src/main/res/layout/fragment_first_pair.xml
@@ -95,7 +95,90 @@
                         android:shadowRadius="4"
                         android:shadowColor="@color/appBlack"
                         app:layout_constraintHorizontal_bias="0.56" />
+
+
                 </LinearLayout>
+
+
+                <LinearLayout
+                    android:id="@+id/tab2"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical">
+                    <TextView
+                        android:text="$ brew install kryptco/tap/kr\n$ kr pair"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintLeft_toLeftOf="parent"
+                        app:layout_constraintRight_toRightOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/installInstructions"
+                        android:layout_width="match_parent"
+                        android:textSize="16sp"
+                        android:fontFamily="monospace"
+                        android:textColor="@color/appWhite"
+                        android:background="@drawable/terminal_bg_bottom"
+                        android:paddingLeft="6dp"
+                        android:paddingTop="6dp"
+                        android:paddingBottom="10dp"
+                        android:typeface="monospace"
+                        android:textStyle="normal|bold"
+                        android:shadowRadius="4"
+                        android:shadowColor="@color/appBlack"
+                        app:layout_constraintHorizontal_bias="0.56" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/tab3"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical">
+                    <TextView
+                        android:text="$ npm install -g krd # mac only\n$ kr pair"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintLeft_toLeftOf="parent"
+                        app:layout_constraintRight_toRightOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/installInstructions"
+                        android:layout_width="match_parent"
+                        android:textSize="16sp"
+                        android:fontFamily="monospace"
+                        android:textColor="@color/appWhite"
+                        android:background="@drawable/terminal_bg_bottom"
+                        android:paddingLeft="6dp"
+                        android:paddingTop="6dp"
+                        android:paddingBottom="10dp"
+                        android:typeface="monospace"
+                        android:textStyle="normal|bold"
+                        android:shadowRadius="4"
+                        android:shadowColor="@color/appBlack"
+                        app:layout_constraintHorizontal_bias="0.56" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/tab4"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical">
+                    <TextView
+                        android:text="$ # go to https://krypt.co/install\n$ kr pair"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintLeft_toLeftOf="parent"
+                        app:layout_constraintRight_toRightOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/installInstructions"
+                        android:layout_width="match_parent"
+                        android:textSize="16sp"
+                        android:fontFamily="monospace"
+                        android:textColor="@color/appWhite"
+                        android:background="@drawable/terminal_bg_bottom"
+                        android:paddingLeft="6dp"
+                        android:paddingTop="6dp"
+                        android:paddingBottom="10dp"
+                        android:typeface="monospace"
+                        android:textStyle="normal|bold"
+                        android:shadowRadius="4"
+                        android:shadowColor="@color/appBlack"
+                        app:layout_constraintHorizontal_bias="0.56" />
+                </LinearLayout>
+
             </FrameLayout>
         </LinearLayout>
     </TabHost>

--- a/app/src/main/res/layout/fragment_help.xml
+++ b/app/src/main/res/layout/fragment_help.xml
@@ -108,6 +108,88 @@
                             android:shadowRadius="4"
                             android:shadowColor="@color/appBlack"
                             app:layout_constraintHorizontal_bias="0.56" />
+
+
+                    </LinearLayout>
+
+
+                    <LinearLayout
+                        android:id="@+id/tab2"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:orientation="vertical">
+                        <TextView
+                            android:text="$ brew install kryptco/tap/kr\n$ kr pair"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintLeft_toLeftOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/installInstructions"
+                            android:layout_width="match_parent"
+                            android:textSize="16sp"
+                            android:fontFamily="monospace"
+                            android:textColor="@color/appWhite"
+                            android:background="@drawable/terminal_bg_bottom"
+                            android:paddingLeft="6dp"
+                            android:paddingTop="6dp"
+                            android:paddingBottom="10dp"
+                            android:typeface="monospace"
+                            android:textStyle="normal|bold"
+                            android:shadowRadius="4"
+                            android:shadowColor="@color/appBlack"
+                            app:layout_constraintHorizontal_bias="0.56" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/tab3"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:orientation="vertical">
+                        <TextView
+                            android:text="$ npm install -g krd # mac only\n$ kr pair"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintLeft_toLeftOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/installInstructions"
+                            android:layout_width="match_parent"
+                            android:textSize="16sp"
+                            android:fontFamily="monospace"
+                            android:textColor="@color/appWhite"
+                            android:background="@drawable/terminal_bg_bottom"
+                            android:paddingLeft="6dp"
+                            android:paddingTop="6dp"
+                            android:paddingBottom="10dp"
+                            android:typeface="monospace"
+                            android:textStyle="normal|bold"
+                            android:shadowRadius="4"
+                            android:shadowColor="@color/appBlack"
+                            app:layout_constraintHorizontal_bias="0.56" />
+
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/tab4"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:orientation="vertical">
+                        <TextView
+                            android:text="$ # go to https://krypt.co/install\n$ kr pair"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintLeft_toLeftOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/installInstructions"
+                            android:layout_width="match_parent"
+                            android:textSize="16sp"
+                            android:fontFamily="monospace"
+                            android:textColor="@color/appWhite"
+                            android:background="@drawable/terminal_bg_bottom"
+                            android:paddingLeft="6dp"
+                            android:paddingTop="6dp"
+                            android:paddingBottom="10dp"
+                            android:typeface="monospace"
+                            android:textStyle="normal|bold"
+                            android:shadowRadius="4"
+                            android:shadowColor="@color/appBlack"
+                            app:layout_constraintHorizontal_bias="0.56" />
                     </LinearLayout>
                 </FrameLayout>
             </LinearLayout>


### PR DESCRIPTION
Move all setup/teardown work to a separate thread, using a threadpool with a single thread to synchronize start/stop operations. This frees up the UI thread, making the UI more fluid.

The result is that there is no UI glitching when the camera is enabled/disabled, and it is therefore managed instantly on visibility hints.