### PR TITLE
Instant camera setup/teardown on visibility hint (#59)

### DIFF
--- a/app/src/main/java/co/krypt/kryptonite/onboarding/FirstPairFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/onboarding/FirstPairFragment.java
@@ -62,10 +62,22 @@ public class FirstPairFragment extends Fragment {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        pairFragment.setUserVisibleHint(true);
+        pairFragment.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        pairFragment.onPause();
+        super.onPause();
+    }
+
+    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         getChildFragmentManager().beginTransaction().add(R.id.pairLayout, pairFragment).commit();
-        pairFragment.setUserVisibleHint(true);
 
         View root = inflater.inflate(R.layout.fragment_first_pair, container, false);
         Button nextButton = (Button) root.findViewById(R.id.nextButton);

--- a/app/src/main/java/co/krypt/kryptonite/pairing/CameraPreview.java
+++ b/app/src/main/java/co/krypt/kryptonite/pairing/CameraPreview.java
@@ -2,13 +2,13 @@ package co.krypt.kryptonite.pairing;
 
 
 import android.content.Context;
+import android.graphics.PixelFormat;
 import android.hardware.Camera;
 import android.util.Log;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
 import java.io.IOException;
-import java.util.List;
 
 /** A basic Camera preview class https://developer.android.com/guide/topics/media/camera.html#preview-layout */
 
@@ -26,36 +26,27 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
         // underlying surface is created and destroyed.
         mHolder = getHolder();
         mHolder.addCallback(this);
-        // deprecated setting, but required on Android versions prior to 3.0
-        mHolder.setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);
     }
 
-    public void surfaceCreated(SurfaceHolder holder) {
-        Log.d(TAG, "surfaceCreated");
-    }
+    public void surfaceCreated(SurfaceHolder holder) {}
+    public void surfaceDestroyed(SurfaceHolder holder) {}
+    public void surfaceChanged(SurfaceHolder holder, int format, int w, int h) {}
 
-    public void surfaceDestroyed(SurfaceHolder holder) {
-    }
-
-    public void setCamera(Camera camera) {
+    public void setup(Camera camera) {
         // The Surface has been created, now tell the camera where to draw the preview.
         try {
             camera.setPreviewDisplay(mHolder);
-            camera.startPreview();
-            List<String> focusModes = camera.getParameters().getSupportedFocusModes();
-            if (focusModes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
-                Camera.Parameters params = camera.getParameters();
-                params.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
-                camera.setParameters(params);
-            }
             previewSize = camera.getParameters().getPreviewSize();
         } catch (IOException e) {
             Log.d(TAG, "Error setting camera preview: " + e.getMessage());
         }
     }
 
-    public void surfaceChanged(SurfaceHolder holder, int format, int w, int h) {
-        return;
+    public void clear() {
+        // This trick rebuilds the surface, making it black again. Starting with a black surface
+        // while the camera loads looks nicer than having an odd frozen image from previous run.
+        mHolder.setFormat(PixelFormat.TRANSPARENT);
+        mHolder.setFormat(PixelFormat.OPAQUE);
     }
 
     public Camera.Size getPreviewSize() {


### PR DESCRIPTION
* add "Always ask for unknown hosts" setting per-pairing, default true (#58)

* change case of host public key mismatched error

* add other install options

* send analytic on known_host delete

* match knownhostsedit page view analytic with iOS

* Instant camera setup/teardown on visibility hint

Move all setup/teardown work to a separate thread, using a threadpool
with a single thread to synchronize start/stop operations. This
frees up the UI thread, making the UI more fluid.

* Manage camera onResume/onPause

This is necessary to allow other applications to acquire the camera
while Kryptonite is in the background on their pairing screen.
The surface is not cleared when camera activates onResume.

* Avoid starting/stopping camera repeatedly

If the user went between tabs very fast, start/stop requests could
queue up, causing the camera to be stuck in a start/stop loop for
quite long. This is avoided by queueing an updateCamera method that
evaluates whether the camera is wanted before performing an action,
rather than directly queueing the start/stop methods.

* resume PairFragment within FirstPairFragment

* remove camera.unlock()

without correpsonding camera.lock(), unlock() seems to lock the camera
i.e. after navigating to and away from PairFragment, could not turn on
flashlight until killing Kryptonite


I agree to license all rights to my contributions in each modified
file exclusively to KryptCo, Inc.