### PR TITLE
Thread and lock cleanup

### DIFF
--- a/app/src/main/java/co/krypt/kryptonite/MainActivity.java
+++ b/app/src/main/java/co/krypt/kryptonite/MainActivity.java
@@ -240,9 +240,9 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onPause() {
-        super.onPause();
-        Log.i(TAG, "pause");
         silo.stop();
+        Log.i(TAG, "pause");
+        super.onPause();
     }
 
     @Override

--- a/app/src/main/java/co/krypt/kryptonite/analytics/Analytics.java
+++ b/app/src/main/java/co/krypt/kryptonite/analytics/Analytics.java
@@ -42,7 +42,7 @@ public class Analytics {
     public String getClientID() {
         synchronized (lock) {
             if (!preferences.contains(CLIENT_ID_KEY)) {
-                preferences.edit().putString(CLIENT_ID_KEY, Base64.encodeAsString(SecureRandom.getSeed(16))).commit();
+                preferences.edit().putString(CLIENT_ID_KEY, Base64.encodeAsString(SecureRandom.getSeed(16))).apply();
             }
             return preferences.getString(CLIENT_ID_KEY, "");
         }
@@ -164,7 +164,7 @@ public class Analytics {
     public void setAnalyticsDisabled(boolean disabled) {
         synchronized (lock) {
             postEvent("analytics", disabled ? "disabled" : "enabled", null, null, true);
-            preferences.edit().putBoolean(ANALYTICS_DISABLED_KEY, disabled).commit();
+            preferences.edit().putBoolean(ANALYTICS_DISABLED_KEY, disabled).apply();
         }
     }
 }

--- a/app/src/main/java/co/krypt/kryptonite/analytics/Analytics.java
+++ b/app/src/main/java/co/krypt/kryptonite/analytics/Analytics.java
@@ -28,7 +28,7 @@ public class Analytics {
     public static final String ANALYTICS_DISABLED_KEY = "ANALYTICS_DISABLED";
     public static final String CLIENT_ID_KEY = "CLIENT_ID";
     public static final String PUBLISHED_EMAIL_KEY = "PUBLISHED_EMAIL";
-    private static Object lock = new Object();
+    private static final Object lock = new Object();
     private SharedPreferences preferences;
 
     private static final String TRACKING_ID() {

--- a/app/src/main/java/co/krypt/kryptonite/analytics/Analytics.java
+++ b/app/src/main/java/co/krypt/kryptonite/analytics/Analytics.java
@@ -72,7 +72,7 @@ public class Analytics {
                             connection.setRequestMethod("PUT");
                             try {
                                 InputStream in = new BufferedInputStream(connection.getInputStream());
-                                preferences.edit().putString(PUBLISHED_EMAIL_KEY, email);
+                                preferences.edit().putString(PUBLISHED_EMAIL_KEY, email).apply();
                             } finally {
                                 connection.disconnect();
                             }

--- a/app/src/main/java/co/krypt/kryptonite/crypto/EdKeyManager.java
+++ b/app/src/main/java/co/krypt/kryptonite/crypto/EdKeyManager.java
@@ -37,7 +37,7 @@ public class EdKeyManager implements KeyManagerI {
                 if (result != 0) {
                     throw new CryptoException("non-zero sodium result: " + result);
                 }
-                preferences.edit().putString(SSH_KEYPAIR_KEY + "." + tag, Base64.encodeAsString(sk)).commit();
+                preferences.edit().putString(SSH_KEYPAIR_KEY + "." + tag, Base64.encodeAsString(sk)).apply();
                 return new EdSSHKeyPair(pk, sk);
             }
             byte[] sk = Base64.decode(skB64);
@@ -58,7 +58,7 @@ public class EdKeyManager implements KeyManagerI {
 
     public void deleteKeyPair(String tag) throws Exception {
         synchronized (lock) {
-            preferences.edit().putString(SSH_KEYPAIR_KEY + "." + tag, null).commit();
+            preferences.edit().putString(SSH_KEYPAIR_KEY + "." + tag, null).apply();
         }
     }
 

--- a/app/src/main/java/co/krypt/kryptonite/me/MeStorage.java
+++ b/app/src/main/java/co/krypt/kryptonite/me/MeStorage.java
@@ -19,7 +19,7 @@ import co.krypt.kryptonite.protocol.Profile;
 
 public class MeStorage {
     private static final String TAG = "MeStorage";
-    private static Object lock = new Object();
+    private static final Object lock = new Object();
     private SharedPreferences preferences;
     private final Context context;
 

--- a/app/src/main/java/co/krypt/kryptonite/me/MeStorage.java
+++ b/app/src/main/java/co/krypt/kryptonite/me/MeStorage.java
@@ -51,13 +51,13 @@ public class MeStorage {
 
     public void delete() {
         synchronized (lock) {
-            preferences.edit().putString("ME", "").commit();
+            preferences.edit().putString("ME", "").apply();
         }
     }
 
     public void set(Profile profile) {
         synchronized (lock) {
-            preferences.edit().putString("ME", JSON.toJson(profile)).commit();
+            preferences.edit().putString("ME", JSON.toJson(profile)).apply();
         }
     }
 

--- a/app/src/main/java/co/krypt/kryptonite/onboarding/OnboardingActivity.java
+++ b/app/src/main/java/co/krypt/kryptonite/onboarding/OnboardingActivity.java
@@ -158,8 +158,8 @@ public class OnboardingActivity extends FragmentActivity {
 
     @Override
     protected void onPause() {
-        super.onPause();
         Silo.shared(getApplicationContext()).stop();
+        super.onPause();
     }
 
     @Override

--- a/app/src/main/java/co/krypt/kryptonite/onboarding/OnboardingProgress.java
+++ b/app/src/main/java/co/krypt/kryptonite/onboarding/OnboardingProgress.java
@@ -46,7 +46,7 @@ public class OnboardingProgress {
 
     public void setStage(OnboardingStage stage) {
         synchronized (lock) {
-            preferences.edit().putString(CURRENT_STAGE_KEY, stage.toString()).commit();
+            preferences.edit().putString(CURRENT_STAGE_KEY, stage.toString()).apply();
         }
     }
 

--- a/app/src/main/java/co/krypt/kryptonite/pairing/PairDialogFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/pairing/PairDialogFragment.java
@@ -62,21 +62,14 @@ public class PairDialogFragment extends DialogFragment {
                 .setPositiveButton("Pair", new DialogInterface.OnClickListener() {
                     public void onClick(final DialogInterface dialog, int id) {
                         if (getTargetFragment() instanceof PairListener) {
-                            Runnable onPair =
-                                    new Runnable() {
-                                        @Override
-                                        public void run() {
-                                            final PairListener listener = (PairListener) getTargetFragment();
-                                            new Thread(new Runnable() {
-                                                @Override
-                                                public void run() {
-                                                    //TODO: detect existing pairings
-                                                    analytics.postEvent("device", "pair", "new", null, false);
-                                                    listener.pair();
-                                                }
-                                            }).start();
-                                        }
-                                    };
+                            Runnable onPair = new Runnable() {
+                                @Override
+                                public void run() {
+                                    final PairListener listener = (PairListener) getTargetFragment();
+                                    analytics.postEvent("device", "pair", "new", null, false);
+                                    listener.pair();
+                                }
+                            };
                             Activity activity = getActivity();
                             if (activity instanceof OnboardingActivity) {
                                 onPair.run();
@@ -94,13 +87,8 @@ public class PairDialogFragment extends DialogFragment {
                     public void onClick(DialogInterface dialog, int id) {
                         if (getTargetFragment() instanceof PairListener) {
                             final PairListener listener = (PairListener) getTargetFragment();
-                            new Thread(new Runnable() {
-                                @Override
-                                public void run() {
-                                    analytics.postEvent("device", "pair", "reject", null, false);
-                                    listener.cancel();
-                                }
-                            }).start();
+                            analytics.postEvent("device", "pair", "reject", null, false);
+                            listener.cancel();
                         }
                     }
                 });

--- a/app/src/main/java/co/krypt/kryptonite/pairing/PairDialogFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/pairing/PairDialogFragment.java
@@ -65,6 +65,7 @@ public class PairDialogFragment extends DialogFragment {
                             Runnable onPair = new Runnable() {
                                 @Override
                                 public void run() {
+                                    //TODO: detect existing pairings
                                     final PairListener listener = (PairListener) getTargetFragment();
                                     analytics.postEvent("device", "pair", "new", null, false);
                                     listener.pair();

--- a/app/src/main/java/co/krypt/kryptonite/pairing/Pairings.java
+++ b/app/src/main/java/co/krypt/kryptonite/pairing/Pairings.java
@@ -91,7 +91,7 @@ public class Pairings {
 
     public void clearOldPairings() {
         synchronized (lock) {
-            preferences.edit().remove(OLD_PAIRINGS_KEY).commit();
+            preferences.edit().remove(OLD_PAIRINGS_KEY).apply();
         }
     }
 
@@ -100,7 +100,7 @@ public class Pairings {
         for (Pairing pairing : pairings) {
             jsonPairings.add(JSON.toJson(pairing));
         }
-        preferences.edit().putStringSet(PAIRINGS_KEY, jsonPairings).commit();
+        preferences.edit().putStringSet(PAIRINGS_KEY, jsonPairings).apply();
         return pairings;
     }
 
@@ -126,7 +126,7 @@ public class Pairings {
             if (!approved) {
                 editor.putLong(pairingApprovedUntilKey(pairingUUID), -1);
             }
-            editor.commit();
+            editor.apply();
         }
     }
 
@@ -149,7 +149,7 @@ public class Pairings {
             preferences.edit()
                     .putLong(pairingApprovedUntilKey(pairingUUID), time)
                     .putBoolean(pairingApprovedKey(pairingUUID), false)
-                    .commit();
+                    .apply();
         }
     }
 
@@ -208,7 +208,7 @@ public class Pairings {
             prefs.remove(getSettingsKey(pairing, REQUIRE_UNKNOWN_HOST_MANUAL_APPROVAL))
                     .remove(pairingApprovedKey(pairing.getUUIDString()))
                     .remove(pairingApprovedUntilKey(pairing.getUUIDString()))
-                    .commit();
+                    .apply();
         }
     }
 
@@ -284,7 +284,7 @@ public class Pairings {
 
     public void setRequireUnknownHostManualApproval(Pairing pairing, boolean requireApproval) {
         synchronized (lock) {
-            preferences.edit().putBoolean(getSettingsKey(pairing, REQUIRE_UNKNOWN_HOST_MANUAL_APPROVAL), requireApproval).commit();
+            preferences.edit().putBoolean(getSettingsKey(pairing, REQUIRE_UNKNOWN_HOST_MANUAL_APPROVAL), requireApproval).apply();
         }
     }
 }

--- a/app/src/main/java/co/krypt/kryptonite/pairing/Pairings.java
+++ b/app/src/main/java/co/krypt/kryptonite/pairing/Pairings.java
@@ -26,7 +26,7 @@ import co.krypt.kryptonite.protocol.JSON;
 public class Pairings {
     private static final String OLD_PAIRINGS_KEY = "PAIRINGS";
     private static final String PAIRINGS_KEY = "PAIRINGS_2";
-    private static Object lock = new Object();
+    private static final Object lock = new Object();
     private final SharedPreferences preferences;
     private final Context context;
     private final Analytics analytics;

--- a/app/src/main/java/co/krypt/kryptonite/policy/LocalAuthentication.java
+++ b/app/src/main/java/co/krypt/kryptonite/policy/LocalAuthentication.java
@@ -29,7 +29,7 @@ public class LocalAuthentication {
     public static synchronized void onSuccess() {
         final Runnable successCallback = lastSuccessCallback;
         if (successCallback != null) {
-            new Thread(successCallback).start();
+            successCallback.run();
         }
         lastSuccessCallback = null;
     }

--- a/app/src/main/java/co/krypt/kryptonite/settings/Settings.java
+++ b/app/src/main/java/co/krypt/kryptonite/settings/Settings.java
@@ -27,7 +27,7 @@ public class Settings {
 
     public void setApprovedNotificationsEnabled(boolean b) {
         synchronized (lock) {
-            preferences.edit().putBoolean(ENABLE_APPROVED_NOTIFICATIONS_KEY, b).commit();
+            preferences.edit().putBoolean(ENABLE_APPROVED_NOTIFICATIONS_KEY, b).apply();
         }
     }
 
@@ -39,7 +39,7 @@ public class Settings {
 
     public void setSilenceNotifications(boolean b) {
         synchronized (lock) {
-            preferences.edit().putBoolean(SILENCE_NOTIFICATIONS_KEY, b).commit();
+            preferences.edit().putBoolean(SILENCE_NOTIFICATIONS_KEY, b).apply();
         }
     }
 

--- a/app/src/main/java/co/krypt/kryptonite/settings/SettingsFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/settings/SettingsFragment.java
@@ -168,7 +168,7 @@ public class SettingsFragment extends Fragment {
                     startActivity(sendIntent);
                 } catch (IOException e) {
                     e.printStackTrace();
-                    Toast.makeText(v.getContext(), "Error exporting audit log: " + e.getMessage(), Toast.LENGTH_LONG);
+                    Toast.makeText(v.getContext(), "Error exporting audit log: " + e.getMessage(), Toast.LENGTH_LONG).show();
                 }
             }
         });

--- a/app/src/main/java/co/krypt/kryptonite/settings/SettingsFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/settings/SettingsFragment.java
@@ -74,15 +74,20 @@ public class SettingsFragment extends Fragment {
                         new Runnable() {
                             @Override
                             public void run() {
-                                try {
-                                    new Analytics(getContext()).postEvent("keypair", "destroy", null, null, false);
-                                    Silo.shared(getContext()).unpairAll();
-                                    KeyManager.deleteAllMeKeyPairs(getContext());
-                                    new MeStorage(getContext()).delete();
-                                    startActivity(new Intent(getContext(), OnboardingActivity.class));
-                                } catch (Exception e) {
-                                    e.printStackTrace();
-                                }
+                                new Thread(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        try {
+                                            new Analytics(getContext()).postEvent("keypair", "destroy", null, null, false);
+                                            Silo.shared(getContext()).unpairAll();
+                                            KeyManager.deleteAllMeKeyPairs(getContext());
+                                            new MeStorage(getContext()).delete();
+                                            startActivity(new Intent(getContext(), OnboardingActivity.class));
+                                        } catch (Exception e) {
+                                            e.printStackTrace();
+                                        }
+                                    }
+                                }).start();
                             }
                         });
             }

--- a/app/src/main/java/co/krypt/kryptonite/silo/Silo.java
+++ b/app/src/main/java/co/krypt/kryptonite/silo/Silo.java
@@ -158,8 +158,7 @@ public class Silo {
         }
     }
 
-    public Pairing pair(PairingQR pairingQR) throws CryptoException, TransportException {
-        Pairing pairing = Pairing.generate(pairingQR);
+    public Pairing pair(Pairing pairing) throws CryptoException, TransportException {
         synchronized (pairingsLock) {
             Pairing oldPairing = activePairingsByUUID.get(pairing.uuid);
             if (oldPairing != null) {

--- a/app/src/main/java/co/krypt/kryptonite/transport/SQSPoller.java
+++ b/app/src/main/java/co/krypt/kryptonite/transport/SQSPoller.java
@@ -27,6 +27,7 @@ public class SQSPoller {
         new Thread(new Runnable() {
             @Override
             public void run() {
+                Log.d(TAG, "starting polling " + pairing.workstationName);
                 while (true) {
                     if (stopped.get()) {
                         Log.d(TAG, "stopped polling " + pairing.workstationName);


### PR DESCRIPTION
This PR cleans up thread and lock handling, primarily around Silo and pairings.

The purpose of this cleanup is to improve code clarity, and reduce chances of multi-threaded surprises, as more code is under natural synchronization of the UI thread.

I'd recommend checking the individual commits, rather than the full PR. They're all self-contained. There are a few minor cleanup commits in there as well. They're all changes with a purpose, despite how tempted I have been to fix everything Android Studio has to say...

Have a look, see what you think.